### PR TITLE
ci: migrate soldeer publishing to rainix-autopublish

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: rain-lib-memkv
+    secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,8 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags: ["v*"]
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-lib-memkv"
+version = "0.1.0"
+
 [profile.default]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Part of removing the manual `publish-soldeer` reusable from rainix. Adds `[package].version = 0.1.0` (current registry release) to foundry.toml, replaces the tag-driven wrapper with `rainix-autopublish` (`soldeer-package: rain-lib-memkv`). Release model: tag → bump version + merge to main. No publish fires from this PR.